### PR TITLE
Update [id].vue: Fix for datocms-image showing nothing

### DIFF
--- a/pages/posts/[id].vue
+++ b/pages/posts/[id].vue
@@ -114,7 +114,7 @@ const renderBlock = ({ record }) => {
       'div',
       { class: "mb-5" },
       [
-        h("datocms-image", { props: { data: record.image.responsiveImage } }),
+        h(DatocmsImage, {  data: record.image.responsiveImage }),
       ]
     );
   }


### PR DESCRIPTION
A fix for https://community.datocms.com/t/how-to-display-images-from-structured-text-block/4865

It looks like our Nuxt.js wasn't correctly showing images inside Structured Text blocks.

## In the CMS:
![image](https://github.com/datocms/nuxtjs-demo/assets/11964962/75270c46-e0f0-4bef-9eac-c476c4b6cbb7)

## Before:
![image](https://github.com/datocms/nuxtjs-demo/assets/11964962/06f7b68c-e728-4a7d-9d7f-f8fb1ccc08f6)

The image block isn't showing up. The inspector shows this:

```
<datocms-image props="[object Object]"></datocms-image>
```

![image](https://github.com/datocms/nuxtjs-demo/assets/11964962/99153c64-a013-4791-ac38-9279c5b0b2ac)


## After:
![image](https://github.com/datocms/nuxtjs-demo/assets/11964962/06f7b68c-e728-4a7d-9d7f-f8fb1ccc08f6)

